### PR TITLE
Bump-up versions and update links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ##
-## Build
+## THe build image
 ##
 
-FROM golang:1.16-buster AS build
+FROM golang:1.19-bookworm AS build
 
 WORKDIR /app
 
@@ -15,10 +15,10 @@ COPY *.go ./
 RUN go build -o /docker-gs-ping-roach
 
 ##
-## Deploy
+## The runtime image
 ##
 
-FROM gcr.io/distroless/base-debian10
+FROM gcr.io/distroless/base-debian12
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,5 @@
 # docker-gs-ping-roach
- 
-A slightly more advanced Go server/microservice example for [Docker's Go Language Guide](https://docs.docker.com/language/golang/). 
 
-Notable features:
+A sample Go web application example for [Docker's Go language-specific guide](https://docs.docker.com/language/golang/).
 
-* Extends the basic example introduced in [olliefr/docker-gs-ping](https://github.com/olliefr/docker-gs-ping).
-* Uses [CockroachDB](https://github.com/cockroachdb/cockroach) database engine.
-* Introduces [Docker Compose](https://docs.docker.com/compose/).
-
-## Contributing
-
-This was written for an _introduction_ section of the Docker tutorial and as such it favours brevity and pedagogical clarity over robustness. 
-
-Thus, feedback is welcome, but please no nits or pedantry. Ain't nobody got time for that 🙃
-
-## License
-
-[Apache-2.0 License](LICENSE)
+This application builds on the basic example introduced in [docker/docker-gs-ping](https://github.com/docker/docker-gs-ping) and uses [CockroachDB](https://github.com/cockroachdb/cockroach) database engine.

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,24 @@
-module github.com/olliefr/docker-gs-ping-roach
+module github.com/docker/docker-gs-ping-roach
 
-go 1.16
+go 1.19
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/cockroachdb/cockroach-go/v2 v2.1.1
 	github.com/labstack/echo/v4 v4.3.0
+)
+
+require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/lib/pq v1.10.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
 	golang.org/x/net v0.0.0-20210508051633-16afe75a6701 // indirect
 	golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -160,7 +160,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096 h1:5PbJGn5Sp3GEUjJ61aYbUP6RIo3Z3r2E4Tv9y2z8UHo=
 golang.org/x/sys v0.0.0-20210507161434-a76c4d0a0096/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
A number of links in this forked repo still referenced the original repository on my GitHub account. That repository was archived.

This PR updates the links in the docs and the Go modules configuration to reference this repository.


- Remove irrelevant information from the README. Inspired by [docker/docker-dotnet-sample](https://github.com/docker/docker-dotnet-sample).
- Bump up Go version and update `go.mod` to point to Docker's GitHub repository.
- Bump-up distroless base image version for the runtime image in multi-stage build.